### PR TITLE
Improve wallet guidance and pool token handling

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -399,6 +399,13 @@ body {
   color: var(--text-secondary);
 }
 
+.field-caption {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  margin: -4px 0 0;
+}
+
 .amount-field {
   position: relative;
   border-radius: 16px;

--- a/functions/addLiquidity.js
+++ b/functions/addLiquidity.js
@@ -10,7 +10,6 @@ import {
 
 function parseBody(body) {
   if (!body) return {};
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
   try {
     return JSON.parse(body);
   } catch (error) {
@@ -18,7 +17,7 @@ codex/verify-amm-liquidity-pool-token-functionality-8fk14o
   }
 }
 
-async function addLiquidityHandler(event) {
+async function handler(event) {
   if (event.httpMethod && event.httpMethod.toUpperCase() === "OPTIONS") {
     return { statusCode: 204, body: "" };
   }
@@ -37,23 +36,6 @@ async function addLiquidityHandler(event) {
       tokenAAddress,
       tokenBAddress,
     } = payload;
-  try {
-    return JSON.parse(body);
-  } catch (error) {
-    throw new Error("Invalid JSON body");
-  }
-}
-
-async function handler(event) {
-  if (event.httpMethod && event.httpMethod.toUpperCase() === "OPTIONS") {
-    return { statusCode: 204, body: "" };
-  }
-
-  let client;
-  try {
-    const payload = parseBody(event.body);
-    const { tokenA, tokenB, amountA, amountB, seed, accountIndex = 0 } = payload;
-master
 
     if (!tokenA || !tokenB) {
       throw new Error("Token symbols are required");
@@ -65,7 +47,6 @@ master
       throw new Error("A signer seed is required to add liquidity");
     }
 
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
     const normalizedOverrides = { ...rawTokenAddresses };
     if (tokenAAddress) {
       normalizedOverrides[tokenA] = tokenAAddress;
@@ -102,24 +83,6 @@ codex/verify-amm-liquidity-pool-token-functionality-8fk14o
       throw new Error("Liquidity amounts must be greater than zero");
     }
 
-    client = await createClient({ seed, accountIndex });
-    const context = await loadPoolContext(client);
-
-    const tokenDetailsA = context.tokens.find((item) => item.symbol === tokenA);
-    const tokenDetailsB = context.tokens.find((item) => item.symbol === tokenB);
-
-    if (!tokenDetailsA || !tokenDetailsB) {
-      throw new Error("Selected pool does not support the provided token pair");
-    }
-
-    const amountARaw = toRawAmount(amountA, tokenDetailsA.decimals);
-    const amountBRaw = toRawAmount(amountB, tokenDetailsB.decimals);
-
-    if (amountARaw <= 0n || amountBRaw <= 0n) {
-      throw new Error("Liquidity amounts must be greater than zero");
-    }
-
-master
     const reserveA = BigInt(tokenDetailsA.reserveRaw);
     const reserveB = BigInt(tokenDetailsB.reserveRaw);
     const totalSupply = BigInt(context.lpToken.supplyRaw || "0");
@@ -200,7 +163,6 @@ master
     return {
       statusCode: 200,
       body: JSON.stringify(response),
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
     };
   } catch (error) {
     console.error("addLiquidity error", error);
@@ -208,14 +170,6 @@ codex/verify-amm-liquidity-pool-token-functionality-8fk14o
       statusCode: 500,
       body: JSON.stringify({ error: error.message || "Add liquidity failed" }),
     };
-    };
-  } catch (error) {
-    console.error("addLiquidity error", error);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: error.message || "Add liquidity failed" }),
-    };
-master
   } finally {
     if (client && typeof client.destroy === "function") {
       try {
@@ -227,7 +181,4 @@ master
   }
 }
 
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
-export const handler = withCors(addLiquidityHandler);
 export const handler = withCors(handler);
-master

--- a/functions/getpool.js
+++ b/functions/getpool.js
@@ -1,16 +1,17 @@
 import { withCors } from "./cors.js";
 import { createClient, loadPoolContext } from "./utils/keeta.js";
 
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
 function parseOverrides(event) {
   if (!event || !event.body) {
     return {};
   }
+
   try {
     const payload = JSON.parse(event.body);
     if (!payload || typeof payload !== "object") {
       return {};
     }
+
     const overrides = {};
     if (payload.poolAccount) {
       overrides.poolAccount = payload.poolAccount;
@@ -28,9 +29,7 @@ function parseOverrides(event) {
   }
 }
 
-async function getPoolHandler(event) {
 async function handler(event) {
-master
   if (event.httpMethod && event.httpMethod.toUpperCase() === "OPTIONS") {
     return { statusCode: 204, body: "" };
   }
@@ -38,11 +37,8 @@ master
   let client;
   try {
     client = await createClient();
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
     const overrides = parseOverrides(event);
     const context = await loadPoolContext(client, overrides);
-    const context = await loadPoolContext(client);
-master
     return {
       statusCode: 200,
       body: JSON.stringify({
@@ -67,7 +63,4 @@ master
   }
 }
 
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
-export const handler = withCors(getPoolHandler);
 export const handler = withCors(handler);
-master

--- a/functions/removeLiquidity.js
+++ b/functions/removeLiquidity.js
@@ -10,7 +10,6 @@ import {
 
 function parseBody(body) {
   if (!body) return {};
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
   try {
     return JSON.parse(body);
   } catch (error) {
@@ -18,7 +17,7 @@ codex/verify-amm-liquidity-pool-token-functionality-8fk14o
   }
 }
 
-async function removeLiquidityHandler(event) {
+async function handler(event) {
   if (event.httpMethod && event.httpMethod.toUpperCase() === "OPTIONS") {
     return { statusCode: 204, body: "" };
   }
@@ -36,23 +35,6 @@ async function removeLiquidityHandler(event) {
       tokenAAddress,
       tokenBAddress,
     } = payload;
-  try {
-    return JSON.parse(body);
-  } catch (error) {
-    throw new Error("Invalid JSON body");
-  }
-}
-
-async function handler(event) {
-  if (event.httpMethod && event.httpMethod.toUpperCase() === "OPTIONS") {
-    return { statusCode: 204, body: "" };
-  }
-
-  let client;
-  try {
-    const payload = parseBody(event.body);
-    const { tokenA, tokenB, lpAmount, seed, accountIndex = 0 } = payload;
-master
 
     if (!tokenA || !tokenB) {
       throw new Error("Token symbols are required");
@@ -64,7 +46,6 @@ master
       throw new Error("A signer seed is required to withdraw liquidity");
     }
 
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
     const normalizedOverrides = { ...rawTokenAddresses };
     if (tokenAAddress) {
       normalizedOverrides[tokenA] = tokenAAddress;
@@ -99,22 +80,6 @@ codex/verify-amm-liquidity-pool-token-functionality-8fk14o
       throw new Error("LP amount must be greater than zero");
     }
 
-    client = await createClient({ seed, accountIndex });
-    const context = await loadPoolContext(client);
-
-    const tokenDetailsA = context.tokens.find((item) => item.symbol === tokenA);
-    const tokenDetailsB = context.tokens.find((item) => item.symbol === tokenB);
-
-    if (!tokenDetailsA || !tokenDetailsB) {
-      throw new Error("Selected pool does not support the provided token pair");
-    }
-
-    const lpAmountRaw = toRawAmount(lpAmount, context.lpToken.decimals);
-    if (lpAmountRaw <= 0n) {
-      throw new Error("LP amount must be greater than zero");
-    }
-
-master
     const reserveA = BigInt(tokenDetailsA.reserveRaw);
     const reserveB = BigInt(tokenDetailsB.reserveRaw);
     const totalSupply = BigInt(context.lpToken.supplyRaw || "0");
@@ -205,7 +170,4 @@ master
   }
 }
 
-codex/verify-amm-liquidity-pool-token-functionality-8fk14o
-export const handler = withCors(removeLiquidityHandler);
 export const handler = withCors(handler);
-master


### PR DESCRIPTION
## Summary
- restore the Netlify function handlers for pool queries and liquidity actions without duplicate conflict markers
- surface the Keeta base token across the swap and pool configuration flows and clarify the wallet account index input
- update the remove-liquidity copy to speak in terms of withdrawing LP tokens instead of burning them

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5edb0e2348328babc9af162466e69