### PR TITLE
Remove stray tokens causing App.js syntax error

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -406,13 +406,7 @@ function WalletControls({ wallet, onWalletChange }) {
       if (!/^[0-9a-fA-F]{64}$/.test(trimmed)) {
         throw new Error("Provide a 64-character hexadecimal seed");
       }
-codex/fix-website-issue-with-seed-paste-hu2rah
 
-codex/fix-website-issue-with-seed-paste-v98bbq
-
-      const index = Number(indexInput) || 0;
-master
-master
       const account = KeetaLib.Account.fromSeed(trimmed, index);
       const address = account.publicKeyString.get();
 


### PR DESCRIPTION
## Summary
- remove stray codex tokens that were breaking the wallet connection logic in `App.js`
- ensure the index handling remains intact after cleaning the syntax error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d621906b5c8328be80a0505ff33c48