### PR TITLE
Fix KTA logo display and add CRACO webpack config

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -1,0 +1,32 @@
+const path = require("path");
+
+function recursivelyUpdateSourceMapLoader(rules) {
+  if (!Array.isArray(rules)) return;
+  for (const rule of rules) {
+    if (!rule || typeof rule !== "object") continue;
+    if (rule.loader && rule.loader.includes("source-map-loader")) {
+      const excludes = [/@keetanetwork[\\/]/, /keetanet-client[\\/]/];
+      if (Array.isArray(rule.exclude)) {
+        rule.exclude.push(...excludes);
+      } else if (rule.exclude) {
+        rule.exclude = [rule.exclude, ...excludes];
+      } else {
+        rule.exclude = excludes;
+      }
+    }
+    if (rule.oneOf) recursivelyUpdateSourceMapLoader(rule.oneOf);
+    if (rule.rules) recursivelyUpdateSourceMapLoader(rule.rules);
+    if (rule.use) recursivelyUpdateSourceMapLoader(Array.isArray(rule.use) ? rule.use : [rule.use]);
+  }
+}
+
+module.exports = {
+  webpack: {
+    configure: (config) => {
+      if (config && config.module && Array.isArray(config.module.rules)) {
+        recursivelyUpdateSourceMapLoader(config.module.rules);
+      }
+      return config;
+    },
+  },
+};

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,9 @@
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@craco/craco": "^7.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2080,6 +2083,55 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
     },
+    "node_modules/@craco/craco": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.1.0.tgz",
+      "integrity": "sha512-oRAcPIKYrfPXp9rSzlsDNeOaVtDiKhoyqSXUoqiK24jCkHr4T8m/a2f74yXIzCbIheoUWDOIfWZyRgFgT+cpqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "autoprefixer": "^10.4.12",
+        "cosmiconfig": "^7.0.1",
+        "cosmiconfig-typescript-loader": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.7",
+        "webpack-merge": "^5.8.0"
+      },
+      "bin": {
+        "craco": "dist/bin/craco.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "react-scripts": "^5.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -3524,6 +3576,34 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -5642,6 +5722,21 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5973,6 +6068,33 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
+      "integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.7.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6631,6 +6753,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -8164,6 +8296,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -9594,6 +9736,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -9795,6 +9950,16 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -11259,6 +11424,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -14865,6 +15037,19 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -16148,6 +16333,70 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -16561,6 +16810,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -16847,6 +17103,21 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
@@ -17047,6 +17318,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -17546,6 +17824,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/client/package.json
+++ b/client/package.json
@@ -35,5 +35,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@craco/craco": "^7.1.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -13,9 +13,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/client/public/tokens/kta.svg
+++ b/client/public/tokens/kta.svg
@@ -1,72 +1,15 @@
-codex/replace-kta-logo-in-file-hnw98q
-<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <linearGradient id="ktaGradient" x1="24" y1="16" x2="112" y2="120" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#1F2937" />
-      <stop offset="1" stop-color="#111827" />
+    <linearGradient id="ktaGradient" x1="20%" y1="10%" x2="80%" y2="90%">
+      <stop offset="0%" stop-color="#1F2937"/>
+      <stop offset="100%" stop-color="#111827"/>
     </linearGradient>
   </defs>
-  <circle cx="64" cy="64" r="60" fill="url(#ktaGradient)" />
-  <path
-    d="M36.5 52.2c-1.4 3.1-2.1 6.5-2.1 10 0 14.3 13.2 31.8 29.6 31.8s29.6-17.5 29.6-31.8c0-3.5-.7-6.9-2.1-10l4.4-14-13.3 6.4c-5-3.4-11.2-5.5-18.6-5.5-7.4 0-13.6 2.1-18.6 5.5l-13.3-6.4 4.4 14Z"
-    stroke="#F9FAFB"
-    stroke-width="4"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    fill="none"
-  />
-  <path
-    d="M48 66c3.5-2.4 7.5-3.7 12-3.7 4.5 0 8.5 1.3 12 3.7"
-    stroke="#F9FAFB"
-    stroke-width="4"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    fill="none"
-  />
-  <path
-    d="M55.6 76.5c0 2.6-2 4.6-4.6 4.6-2.6 0-4.6-2-4.6-4.6 0-2.6 2-4.6 4.6-4.6 2.6 0 4.6 2 4.6 4.6ZM81.6 76.5c0 2.6-2 4.6-4.6 4.6-2.6 0-4.6-2-4.6-4.6 0-2.6 2-4.6 4.6-4.6 2.6 0 4.6 2 4.6 4.6Z"
-    fill="#F9FAFB"
-  />
-  <path
-    d="M64 92c4.2 0 8.1-1.6 10.8-4.2"
-    stroke="#F9FAFB"
-    stroke-width="4"
-    stroke-linecap="round"
-
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <circle cx="256" cy="256" r="248" fill="#121212" />
-  <path
-    d="M96 320c48-88 160-176 288-128 40 16 72 48 96 88"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="32"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M224 304c24 40 96 88 176 32 24-16 32-48 8-72-24-24-64-24-88-8"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="32"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M344 224c32-32 80-32 104 0"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="32"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M120 336c24 16 56 24 88 16"
-    fill="none"
-    stroke="#ffffff"
-    stroke-width="20"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    opacity="0.6"
-master
-  />
+  <circle cx="32" cy="32" r="30" fill="url(#ktaGradient)"/>
+  <circle cx="32" cy="32" r="28" fill="none" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="2"/>
+  <g fill="none" stroke="#F9FAFB" stroke-linecap="round" stroke-linejoin="round" stroke-width="4">
+    <path d="M20 16v32"/>
+    <path d="M20 32l24-16"/>
+    <path d="M20 32l24 16"/>
+  </g>
 </svg>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,7 +11,7 @@ import {
   formatAmount,
   toRawAmount,
 } from "./utils/tokenMath";
-import { TOKENS } from "./config/tokens";
+import { TOKENS, KTA_LOGO_DATA_URL } from "./config/tokens";
 
 const BRAND_LOGO =
   "https://cdn.builder.io/api/v1/image/assets%2Fd70091a6f5494e0195b033a72f7e79ae%2F116ddd439df04721809dcdc66245e3fa?format=webp&width=800";
@@ -283,19 +283,27 @@ const INITIAL_WALLET_STATE = {
 };
 
 function TokenBadge({ symbol, logo }) {
-  const [errored, setErrored] = useState(false);
-  useEffect(() => setErrored(false), [symbol, logo]);
-  const src = errored ? FALLBACK_TOKEN_ICON : logo || getTokenLogoSource(symbol);
+  const initialSrc = useMemo(() => logo || getTokenLogoSource(symbol), [symbol, logo]);
+  const [src, setSrc] = useState(initialSrc);
+  useEffect(() => {
+    setSrc(logo || getTokenLogoSource(symbol));
+  }, [symbol, logo]);
+  const handleError = () => {
+    const upper = String(symbol || "").toUpperCase();
+    if (upper === "KTA" && src !== KTA_LOGO_DATA_URL) {
+      setSrc(KTA_LOGO_DATA_URL);
+      return;
+    }
+    if (src !== FALLBACK_TOKEN_ICON) {
+      setSrc(FALLBACK_TOKEN_ICON);
+    }
+  };
   return (
     <img
       className="token-img"
       src={src}
       alt={symbol ? `${symbol} logo` : "Token logo"}
-      onError={() => {
-        if (!errored) {
-          setErrored(true);
-        }
-      }}
+      onError={handleError}
     />
   );
 }

--- a/client/src/components/LiquidityCard.jsx
+++ b/client/src/components/LiquidityCard.jsx
@@ -202,6 +202,11 @@ export default function LiquidityCard({
                       className="token-trigger-icon"
                       src={getTokenLogo(displayTokenB)}
                       alt={displayTokenB?.symbol || "Token B"}
+                      onError={(e) => {
+                        if (e && e.target && e.target.src) {
+                          e.target.src = "/tokens/default.svg";
+                        }
+                      }}
                     />
                     <span className="token-trigger-symbol">{displayTokenB?.symbol || "—"}</span>
                   </button>

--- a/client/src/components/LiquidityCard.jsx
+++ b/client/src/components/LiquidityCard.jsx
@@ -170,6 +170,11 @@ export default function LiquidityCard({
                       className="token-trigger-icon"
                       src={getTokenLogo(displayTokenA)}
                       alt={displayTokenA?.symbol || "Token A"}
+                      onError={(e) => {
+                        if (e && e.target && e.target.src) {
+                          e.target.src = "/tokens/default.svg";
+                        }
+                      }}
                     />
                     <span className="token-trigger-symbol">{displayTokenA?.symbol || "—"}</span>
                   </button>

--- a/client/src/config/tokens.js
+++ b/client/src/config/tokens.js
@@ -1,9 +1,6 @@
-ai_master_f2269ebdf3d8
 export const KTA_LOGO_DATA_URL =
   "https://cdn.builder.io/api/v1/image/assets%2Fd70091a6f5494e0195b033a72f7e79ae%2F1e2bd437c48f4be5a9c216065f272f94?format=webp";
 
-
-master
 export const TOKENS = {
   KTA: {
     symbol: "KTA",


### PR DESCRIPTION
## Purpose

Based on the conversation history, users reported that the KTA logo was no longer showing on certain fields after a page opened. This PR addresses the logo display issue to ensure the KTA logo appears correctly across the application.

## Code changes

- **Added CRACO configuration**: Created `craco.config.js` to customize webpack build process and exclude source map loading for KTA network packages
- **Updated build scripts**: Modified `package.json` to use CRACO instead of react-scripts for start, build, and test commands
- **Enhanced token logo handling**: Improved error handling in `TokenBadge` component with fallback logic specifically for KTA tokens
- **Added logo error handlers**: Implemented `onError` handlers in `LiquidityCard` component to fallback to default token icons
- **Updated KTA logo SVG**: Simplified the KTA logo SVG file structure and styling
- **Cleaned up token config**: Removed unnecessary code artifacts from `tokens.js` configuration file

The changes ensure robust logo display with proper fallback mechanisms when the primary KTA logo fails to load.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 62`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f8fc3ef85cff4581bc08a88f65382c9a/curry-den)

👀 [Preview Link](https://f8fc3ef85cff4581bc08a88f65382c9a-curry-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f8fc3ef85cff4581bc08a88f65382c9a</projectId>-->
<!--<branchName>curry-den</branchName>-->