### PR TITLE
Fix syntax error in token icon map

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,11 +25,8 @@ const TOKEN_ICON_PATHS = {
   btc: "/tokens/btc.svg",
   kusd: "/tokens/kusd.svg",
   kta: TOKENS.KTA.logo,
-codex/identify-tasks-for-pools-and-swaps-setup-j06fdo
   ride: TOKENS.RIDE.logo,
-
   sbck: TOKENS.SBCK?.logo || "/tokens/default.svg",
-master
   test: "/tokens/default.svg",
 };
 


### PR DESCRIPTION
## Summary
- remove stray tokens from the token icon map to restore valid JavaScript syntax

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7cfd3c41c8328b780c0141e30acb8