### PR TITLE
Fix RIDE decimal handling

### DIFF
--- a/client/src/config/tokens.js
+++ b/client/src/config/tokens.js
@@ -11,7 +11,6 @@ export const TOKENS = {
     symbol: "RIDE",
     name: "Riding Liquid",
     logo: "/tokens/ride.svg",
-    decimals: 5,
   },
   SBCK: {
     symbol: "SBCK",

--- a/functions/utils/keeta.js
+++ b/functions/utils/keeta.js
@@ -28,9 +28,7 @@ const STATIC_TOKEN_ADDRESSES = {
   RIDE: "keeta_anchh4m5ukgvnx5jcwe56k3ltgo4x4kppicdjgcaftx4525gdvknf73fotmdo",
 };
 
-const TOKEN_DECIMAL_OVERRIDES = {
-  RIDE: 5,
-};
+const TOKEN_DECIMAL_OVERRIDES = {};
 
 const EXECUTE_TRANSACTIONS = /^1|true$/i.test(
   process.env.KEETA_EXECUTE_TRANSACTIONS || ""


### PR DESCRIPTION
## Summary
- remove the hard-coded RIDE decimal override in the client token config
- drop the server-side override so pool math uses on-chain metadata values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e08413908328a2e2a3e17be8610e