### PR TITLE
Handle wallet lookup when offline fixtures enabled

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -2,6 +2,7 @@
   "name": "silverback-functions",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@keeta/sdk": "file:./vendor/keeta-sdk",
     "sharp": "^0.33.3"

--- a/functions/removeLiquidity.js
+++ b/functions/removeLiquidity.js
@@ -5,6 +5,7 @@ import {
   calculateWithdrawal,
   createClient,
   formatAmount,
+  loadOfflinePoolContext,
   loadPoolContext,
   toRawAmount,
 } from "./utils/keeta.js";
@@ -84,12 +85,27 @@ async function removeLiquidityHandler(event) {
         ? lpTokenAccount.trim()
         : undefined;
 
-    client = await createClient({ seed, accountIndex });
-    const context = await loadPoolContext(client, {
-      poolAccount: poolOverride,
-      lpTokenAccount: lpTokenOverride,
-      tokenAddresses: normalizedOverrides,
-    });
+    const overrides = {};
+    if (poolOverride) {
+      overrides.poolAccount = poolOverride;
+    }
+    if (lpTokenOverride) {
+      overrides.lpTokenAccount = lpTokenOverride;
+    }
+    if (Object.keys(normalizedOverrides).length > 0) {
+      overrides.tokenAddresses = normalizedOverrides;
+    }
+
+    const offlineContext = await loadOfflinePoolContext(overrides);
+    const usingOfflineContext = Boolean(offlineContext);
+
+    if (!usingOfflineContext) {
+      client = await createClient({ seed, accountIndex });
+    }
+
+    const context = usingOfflineContext
+      ? offlineContext
+      : await loadPoolContext(client, overrides);
 
     const findBySymbol = (symbol) =>
       context.tokens.find((item) => item.symbol === symbol);
@@ -133,16 +149,22 @@ async function removeLiquidityHandler(event) {
 
     let execution = {};
     if (EXECUTE_TRANSACTIONS) {
-      try {
-        execution = await executeRemoveLiquidity(client, context, {
-          lpAmountRaw,
-          amountARaw: amountA,
-          amountBRaw: amountB,
-          tokenA: tokenDetailsA,
-          tokenB: tokenDetailsB,
-        });
-      } catch (execError) {
-        execution = { error: execError.message };
+      if (usingOfflineContext) {
+        execution = {
+          error: "Transaction execution is unavailable when using offline fixtures",
+        };
+      } else {
+        try {
+          execution = await executeRemoveLiquidity(client, context, {
+            lpAmountRaw,
+            amountARaw: amountA,
+            amountBRaw: amountB,
+            tokenA: tokenDetailsA,
+            tokenB: tokenDetailsB,
+          });
+        } catch (execError) {
+          execution = { error: execError.message };
+        }
       }
     }
 

--- a/functions/wallet.js
+++ b/functions/wallet.js
@@ -4,6 +4,7 @@ import {
   DEFAULT_NETWORK,
   decodeMetadata,
   formatAmount,
+  loadOfflinePoolContext,
 } from "./utils/keeta.js";
 
 function parseBody(body) {
@@ -103,6 +104,36 @@ async function walletHandler(event) {
 
     const accountIndex = parseAccountIndex(rawIndex);
     const account = KeetaNet.lib.Account.fromSeed(normalizedSeed, accountIndex);
+    const offlineContext = await loadOfflinePoolContext();
+    if (offlineContext) {
+      const baseToken = offlineContext.baseToken || {};
+      const network = offlineContext.network || DEFAULT_NETWORK;
+      const address = account.publicKeyString.get();
+      const decimalsValue = Number(baseToken.decimals);
+      const decimals = Number.isFinite(decimalsValue) && decimalsValue >= 0 ? decimalsValue : 0;
+      const response = {
+        seed: normalizedSeed,
+        accountIndex,
+        address,
+        identifier: address,
+        network,
+        baseToken: {
+          symbol: baseToken.symbol || "KTA",
+          address: baseToken.address || "",
+          decimals,
+          metadata: baseToken.metadata || {},
+          balanceRaw: "0",
+          balanceFormatted: "0",
+        },
+        message: "Wallet details fetched from offline fixture",
+      };
+
+      return {
+        statusCode: 200,
+        body: JSON.stringify(response),
+      };
+    }
+
     client = KeetaNet.UserClient.fromNetwork(DEFAULT_NETWORK, account);
     const identifierAddress = await loadIdentifier(client, account);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "smoke:offline": "node ./tests/offline-smoke.mjs",
+    "test": "npm run smoke:offline"
   },
   "repository": {
     "type": "git",

--- a/tests/offline-smoke.mjs
+++ b/tests/offline-smoke.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+
+process.env.KEETA_USE_OFFLINE_FIXTURE = "1";
+
+const { handler: addLiquidityHandler } = await import("../functions/addLiquidity.js");
+const { handler: removeLiquidityHandler } = await import("../functions/removeLiquidity.js");
+
+function buildEvent(payload) {
+  return {
+    httpMethod: "POST",
+    headers: {},
+    body: JSON.stringify(payload),
+  };
+}
+
+function parseBody(response) {
+  assert.ok(response, "Response is required");
+  assert.equal(response.statusCode, 200, `Expected 200 response, received ${response.statusCode}`);
+  assert.ok(response.body, "Response body is missing");
+  return JSON.parse(response.body);
+}
+
+const addPayload = {
+  tokenA: "RIDE",
+  tokenB: "USDC",
+  amountA: "100",
+  amountB: "50",
+  seed: "test-seed",
+};
+
+const addResult = parseBody(await addLiquidityHandler(buildEvent(addPayload)));
+assert.ok(addResult.pool?.address, "Add liquidity response should include pool information");
+assert.ok(addResult.minted?.raw, "Add liquidity response should include minted amount");
+assert.notStrictEqual(addResult.minted.raw, "0", "Minted amount should be greater than zero");
+
+const removePayload = {
+  tokenA: "RIDE",
+  tokenB: "USDC",
+  lpAmount: "10",
+  seed: "test-seed",
+};
+
+const removeResult = parseBody(await removeLiquidityHandler(buildEvent(removePayload)));
+assert.ok(removeResult.pool?.address, "Remove liquidity response should include pool information");
+assert.ok(removeResult.withdrawals?.tokenA?.amountRaw, "Remove liquidity response should include token A withdrawal");
+
+console.log("Offline smoke test passed");


### PR DESCRIPTION
## Summary
- short-circuit the wallet handler to reuse offline pool context details when fixtures are active
- return stubbed base token data and zero balances without creating a network client in offline mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7eb94b9f0832899481f3f4d2966aa