### PR TITLE
Restore wallet handler after merge artifact corruption

### DIFF
--- a/functions/wallet.js
+++ b/functions/wallet.js
@@ -10,13 +10,6 @@ import {
 
 const HEX_SEED_REGEX = /^[0-9a-f]{64}$/i;
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-master
-master
 const DEFAULT_WALLET_TIMEOUT_MS = (() => {
   const candidates = [
     process.env.KEETA_WALLET_TIMEOUT_MS,
@@ -34,14 +27,6 @@ const DEFAULT_WALLET_TIMEOUT_MS = (() => {
   return 5000;
 })();
 
- codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-
-master
-master
-master
 function parseBody(body) {
   if (!body) return {};
   try {
@@ -63,13 +48,6 @@ function hashSeedForOffline(seed) {
   return hashed.padEnd(64, "0").slice(0, 64);
 }
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-master
-master
 async function attemptWithTimeout(operation, options = {}) {
   const { label = "network operation", timeoutMs = DEFAULT_WALLET_TIMEOUT_MS } =
     options;
@@ -100,14 +78,6 @@ async function attemptWithTimeout(operation, options = {}) {
   }
 }
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-
-master
-master
-master
 function deriveAccount(seed, accountIndex, allowOfflineFallback) {
   const normalizedSeed = normalizeSeed(seed);
   if (!normalizedSeed) {
@@ -130,16 +100,6 @@ function deriveAccount(seed, accountIndex, allowOfflineFallback) {
   };
 }
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-
-codex/update-addliquidity-and-removeliquidity-functions-ipb5ij
-master
-master
-master
 function parseOverrides(payload) {
   if (!payload || typeof payload !== "object") {
     return {};
@@ -162,16 +122,6 @@ function parseOverrides(payload) {
   return overrides;
 }
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-
-master
-master
-master
-master
 function parseAccountIndex(index) {
   if (index === undefined || index === null || index === "") {
     return 0;
@@ -290,10 +240,6 @@ async function walletHandler(event) {
   let lastErrorMessage = "";
 
   try {
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-master
     const payload = parseBody(event.body);
     overrides = parseOverrides(payload);
     accountIndex = parseAccountIndex(payload.accountIndex);
@@ -302,25 +248,6 @@ master
     account = derived.account;
 
     offlineContext = await loadOfflinePoolContext(overrides);
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-
-codex/update-addliquidity-and-removeliquidity-functions-ipb5ij
-master
-    const payload = parseBody(event.body);
-    const { seed, accountIndex: rawIndex } = payload;
-    const accountIndex = parseAccountIndex(rawIndex);
-    const overrides = parseOverrides(payload);
-    const offlineContext = await loadOfflinePoolContext(overrides);
-    const { normalizedSeed, account } = deriveAccount(
-      seed,
-      accountIndex,
-      true
-    );
-master
-master
     if (offlineContext) {
       const response = buildOfflineWalletResponse({
         normalizedSeed,
@@ -330,364 +257,79 @@ master
         message: "Wallet details fetched from offline fixture",
       });
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
+      return {
+        statusCode: 200,
+        body: JSON.stringify(response),
+      };
+    }
 
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
+    client = await KeetaNet.UserClient.fromNetwork(DEFAULT_NETWORK, account);
+    const [identifierLookup, baseTokenLookup, balanceLookup] = await Promise.all([
+      attemptWithTimeout(() => loadIdentifier(client, account), {
+        label: "wallet identifier lookup",
+      }),
+      attemptWithTimeout(() => loadBaseTokenDetails(client), {
+        label: "base token metadata lookup",
+      }),
+      attemptWithTimeout(() => client.balance(client.baseToken, { account }), {
+        label: "base token balance lookup",
+      }),
+    ]);
 
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
+    const identifierAddress = identifierLookup.ok
+      ? identifierLookup.value
+      : account.publicKeyString.get();
 
-    const { seed, accountIndex: rawIndex } = parseBody(event.body);
-    const accountIndex = parseAccountIndex(rawIndex);
-    const offlineContext = await loadOfflinePoolContext();
-    const { normalizedSeed, account } = deriveAccount(
-      seed,
+    const baseTokenDetails = baseTokenLookup.ok
+      ? baseTokenLookup.value
+      : {
+          symbol: "KTA",
+          address: "",
+          decimals: 0,
+          metadata: {},
+          info: null,
+        };
+
+    const balanceRaw = balanceLookup.ok ? BigInt(balanceLookup.value) : 0n;
+
+    const response = {
+      seed: normalizedSeed,
       accountIndex,
-      Boolean(offlineContext)
-    );
-    if (offlineContext) {
-      const baseToken = offlineContext.baseToken || {};
-      const network = offlineContext.network || DEFAULT_NETWORK;
-      const address = account.publicKeyString.get();
-      const decimalsValue = Number(baseToken.decimals);
-      const decimals = Number.isFinite(decimalsValue) && decimalsValue >= 0 ? decimalsValue : 0;
-      const response = {
-        seed: normalizedSeed,
-        accountIndex,
-        address,
-        identifier: address,
-        network,
-        baseToken: {
-          symbol: baseToken.symbol || "KTA",
-          address: baseToken.address || "",
-          decimals,
-          metadata: baseToken.metadata || {},
-          balanceRaw: "0",
-          balanceFormatted: "0",
-        },
-        message: "Wallet details fetched from offline fixture",
-      };
-master
+      address: account.publicKeyString.get(),
+      identifier: identifierAddress,
+      network: DEFAULT_NETWORK,
+      baseToken: {
+        symbol: baseTokenDetails.symbol,
+        address: baseTokenDetails.address || "",
+        decimals: baseTokenDetails.decimals ?? 0,
+        metadata: baseTokenDetails.metadata || {},
+        balanceRaw: balanceRaw.toString(),
+        balanceFormatted: formatAmount(
+          balanceRaw,
+          baseTokenDetails.decimals ?? 0
+        ),
+      },
+    };
 
-master
-master
-master
-      return {
-        statusCode: 200,
-        body: JSON.stringify(response),
-      };
+    const fallbackReasons = [];
+    if (!identifierLookup.ok) {
+      fallbackReasons.push("identifier");
+    }
+    if (!baseTokenLookup.ok) {
+      fallbackReasons.push("base token metadata");
+    }
+    if (!balanceLookup.ok) {
+      fallbackReasons.push("base token balance");
     }
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-master
-master
-    try {
-      client = KeetaNet.UserClient.fromNetwork(DEFAULT_NETWORK, account);
-      const [identifierLookup, baseTokenLookup, balanceLookup] = await Promise.all([
-        attemptWithTimeout(() => loadIdentifier(client, account), {
-          label: "wallet identifier lookup",
-        }),
-        attemptWithTimeout(() => loadBaseTokenDetails(client), {
-          label: "base token metadata lookup",
-        }),
-        attemptWithTimeout(() => client.balance(client.baseToken, { account }), {
-          label: "base token balance lookup",
-        }),
-      ]);
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-      const identifierAddress = identifierLookup.ok
-        ? identifierLookup.value
-        : account.publicKeyString.get();
-
-      const baseTokenDetails = baseTokenLookup.ok
-        ? baseTokenLookup.value
-        : {
-            symbol: "KTA",
-            address: "",
-            decimals: 0,
-            metadata: {},
-            info: null,
-          };
-
-      const balanceRaw = balanceLookup.ok
-        ? BigInt(balanceLookup.value)
-        : 0n;
-
-      const response = {
-        seed: normalizedSeed,
-        accountIndex,
-        address: account.publicKeyString.get(),
-        identifier: identifierAddress,
-        network: DEFAULT_NETWORK,
-        baseToken: {
-          symbol: baseTokenDetails.symbol,
-          address: baseTokenDetails.address || "",
-          decimals: baseTokenDetails.decimals ?? 0,
-          metadata: baseTokenDetails.metadata || {},
-          balanceRaw: balanceRaw.toString(),
-          balanceFormatted: formatAmount(
-            balanceRaw,
-            baseTokenDetails.decimals ?? 0
-          ),
-        },
-      };
-
-      const fallbackReasons = [];
-      if (!identifierLookup.ok) {
-        fallbackReasons.push("identifier");
-      }
-      if (!baseTokenLookup.ok) {
-        fallbackReasons.push("base token metadata");
-      }
-      if (!balanceLookup.ok) {
-        fallbackReasons.push("base token balance");
-      }
-
-      if (fallbackReasons.length) {
-        response.message = `Wallet details returned with fallback values for ${fallbackReasons.join(", ")}`;
-      }
-
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-      const identifierAddress = identifierLookup.ok
-        ? identifierLookup.value
-        : account.publicKeyString.get();
-
-      const baseTokenDetails = baseTokenLookup.ok
-        ? baseTokenLookup.value
-        : {
-            symbol: "KTA",
-            address: "",
-            decimals: 0,
-            metadata: {},
-            info: null,
-          };
-
-      const balanceRaw = balanceLookup.ok
-        ? BigInt(balanceLookup.value)
-        : 0n;
-
-      const response = {
-        seed: normalizedSeed,
-        accountIndex,
-        address: account.publicKeyString.get(),
-        identifier: identifierAddress,
-        network: DEFAULT_NETWORK,
-        baseToken: {
-          symbol: baseTokenDetails.symbol,
-          address: baseTokenDetails.address || "",
-          decimals: baseTokenDetails.decimals ?? 0,
-          metadata: baseTokenDetails.metadata || {},
-          balanceRaw: balanceRaw.toString(),
-          balanceFormatted: formatAmount(
-            balanceRaw,
-            baseTokenDetails.decimals ?? 0
-          ),
-        },
-      };
-
-      const fallbackReasons = [];
-      if (!identifierLookup.ok) {
-        fallbackReasons.push("identifier");
-      }
-      if (!baseTokenLookup.ok) {
-        fallbackReasons.push("base token metadata");
-      }
-      if (!balanceLookup.ok) {
-        fallbackReasons.push("base token balance");
-      }
-
-      if (fallbackReasons.length) {
-        response.message = `Wallet details returned with fallback values for ${fallbackReasons.join(", ")}`;
-      }
-
-
-      const identifierAddress = identifierLookup.ok
-        ? identifierLookup.value
-        : account.publicKeyString.get();
-
-      const baseTokenDetails = baseTokenLookup.ok
-        ? baseTokenLookup.value
-        : {
-            symbol: "KTA",
-            address: "",
-            decimals: 0,
-            metadata: {},
-            info: null,
-          };
-
-      const balanceRaw = balanceLookup.ok
-        ? BigInt(balanceLookup.value)
-        : 0n;
-
-      const response = {
-        seed: normalizedSeed,
-        accountIndex,
-        address: account.publicKeyString.get(),
-        identifier: identifierAddress,
-        network: DEFAULT_NETWORK,
-        baseToken: {
-          symbol: baseTokenDetails.symbol,
-          address: baseTokenDetails.address || "",
-          decimals: baseTokenDetails.decimals ?? 0,
-          metadata: baseTokenDetails.metadata || {},
-          balanceRaw: balanceRaw.toString(),
-          balanceFormatted: formatAmount(
-            balanceRaw,
-            baseTokenDetails.decimals ?? 0
-          ),
-        },
-      };
-
-      const fallbackReasons = [];
-      if (!identifierLookup.ok) {
-        fallbackReasons.push("identifier");
-      }
-      if (!baseTokenLookup.ok) {
-        fallbackReasons.push("base token metadata");
-      }
-      if (!balanceLookup.ok) {
-        fallbackReasons.push("base token balance");
-      }
-
-      if (fallbackReasons.length) {
-        response.message = `Wallet details returned with fallback values for ${fallbackReasons.join(
-          ", "
-        )}`;
-      }
-
-
-codex/update-addliquidity-and-removeliquidity-functions-ipb5ij
-    try {
-      client = KeetaNet.UserClient.fromNetwork(DEFAULT_NETWORK, account);
-      const identifierAddress = await loadIdentifier(client, account);
-
-      const baseToken = await loadBaseTokenDetails(client);
-      let balanceRaw;
-      try {
-        balanceRaw = await client.balance(client.baseToken, { account });
-      } catch (balanceError) {
-        console.warn("Falling back to zero balance for wallet", balanceError);
-        balanceRaw = 0n;
-      }
-
-codex/update-addliquidity-and-removeliquidity-functions-gkkb6z
-
-    const accountIndex = parseAccountIndex(rawIndex);
-    const account = KeetaNet.lib.Account.fromSeed(normalizedSeed, accountIndex);
-    const offlineContext = await loadOfflinePoolContext();
-    if (offlineContext) {
-      const baseToken = offlineContext.baseToken || {};
-      const network = offlineContext.network || DEFAULT_NETWORK;
-      const address = account.publicKeyString.get();
-      const decimalsValue = Number(baseToken.decimals);
-      const decimals = Number.isFinite(decimalsValue) && decimalsValue >= 0 ? decimalsValue : 0;
-      const response = {
-        seed: normalizedSeed,
-        accountIndex,
-        address,
-        identifier: address,
-        network,
-        baseToken: {
-          symbol: baseToken.symbol || "KTA",
-          address: baseToken.address || "",
-          decimals,
-          metadata: baseToken.metadata || {},
-          balanceRaw: "0",
-          balanceFormatted: "0",
-        },
-        message: "Wallet details fetched from offline fixture",
-      };
-
-      return {
-        statusCode: 200,
-        body: JSON.stringify(response),
-      };
+    if (fallbackReasons.length) {
+      response.message = `Wallet details returned with fallback values for ${fallbackReasons.join(", ")}`;
     }
 
-master
-    client = KeetaNet.UserClient.fromNetwork(DEFAULT_NETWORK, account);
-    const identifierAddress = await loadIdentifier(client, account);
-
-    const baseToken = await loadBaseTokenDetails(client);
-    let balanceRaw;
-    try {
-      balanceRaw = await client.balance(client.baseToken, { account });
-    } catch (balanceError) {
-      console.warn("Falling back to zero balance for wallet", balanceError);
-      balanceRaw = 0n;
-    }
-master
-
-      const response = {
-        seed: normalizedSeed,
-        accountIndex,
-        address: account.publicKeyString.get(),
-        identifier: identifierAddress,
-        network: DEFAULT_NETWORK,
-        baseToken: {
-          symbol: baseToken.symbol,
-          address: baseToken.address,
-          decimals: baseToken.decimals,
-          metadata: baseToken.metadata,
-          balanceRaw: balanceRaw.toString(),
-          balanceFormatted: formatAmount(balanceRaw, baseToken.decimals),
-        },
-      };
-
-master
-master
-master
-      return {
-        statusCode: 200,
-        body: JSON.stringify(response),
-      };
-    } catch (networkError) {
-      console.warn(
-        "Failed to reach network for wallet lookup, returning stub response",
-        networkError
-      );
-
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-      const fixtureContext = offlineContext || (await loadOfflinePoolContext(overrides));
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-      const fixtureContext = offlineContext || (await loadOfflinePoolContext(overrides));
-
-master
-master
-      const response = buildOfflineWalletResponse({
-        normalizedSeed,
-        accountIndex,
-        account,
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-        context: fixtureContext || { network: DEFAULT_NETWORK },
-        message:
-          (fixtureContext && fixtureContext.message) ||
-
-        
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-        context: fixtureContext || { network: DEFAULT_NETWORK },
-        message:
-          (fixtureContext && fixtureContext.message) ||
-
-        context: { network: DEFAULT_NETWORK },
-        message:
-master
-master
-          "Wallet details fetched without contacting the Keeta network",
-      });
-
-      return {
-        statusCode: 200,
-        body: JSON.stringify(response),
-      };
-    }
+    return {
+      statusCode: 200,
+      body: JSON.stringify(response),
+    };
   } catch (error) {
     lastErrorMessage = error?.message || "";
     console.error("wallet error", error);
@@ -727,22 +369,9 @@ master
     };
   } finally {
     if (client && typeof client.destroy === "function") {
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
       const destroyResult = await attemptWithTimeout(() => client.destroy(), {
         label: "Keeta client cleanup",
       });
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-      const destroyResult = await attemptWithTimeout(() => client.destroy(), {
-        label: "Keeta client cleanup",
-      });
-
-      const destroyResult = await attemptWithTimeout(
-        () => client.destroy(),
-        { label: "Keeta client cleanup" }
-      );
-master
-master
       if (!destroyResult.ok) {
         console.warn("Failed to destroy Keeta client", destroyResult.error);
       }

--- a/tests/offline-smoke.mjs
+++ b/tests/offline-smoke.mjs
@@ -4,31 +4,8 @@ process.env.KEETA_USE_OFFLINE_FIXTURE = "1";
 
 const { handler: addLiquidityHandler } = await import("../functions/addLiquidity.js");
 const { handler: removeLiquidityHandler } = await import("../functions/removeLiquidity.js");
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
 const { handler: walletHandler } = await import("../functions/wallet.js");
 
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-const { handler: walletHandler } = await import("../functions/wallet.js");
-
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-const { handler: walletHandler } = await import("../functions/wallet.js");
-
-
-codex/update-addliquidity-and-removeliquidity-functions-ipb5ij
-const { handler: walletHandler } = await import("../functions/wallet.js");
-
-
-codex/update-addliquidity-and-removeliquidity-functions-gkkb6z
-const { handler: walletHandler } = await import("../functions/wallet.js");
-
-master
-
-master
-master
-master
-master
 function buildEvent(payload) {
   return {
     httpMethod: "POST",
@@ -39,7 +16,11 @@ function buildEvent(payload) {
 
 function parseBody(response) {
   assert.ok(response, "Response is required");
-  assert.equal(response.statusCode, 200, `Expected 200 response, received ${response.statusCode}`);
+  assert.equal(
+    response.statusCode,
+    200,
+    `Expected 200 response, received ${response.statusCode}`
+  );
   assert.ok(response.body, "Response body is missing");
   return JSON.parse(response.body);
 }
@@ -53,9 +34,19 @@ const addPayload = {
 };
 
 const addResult = parseBody(await addLiquidityHandler(buildEvent(addPayload)));
-assert.ok(addResult.pool?.address, "Add liquidity response should include pool information");
-assert.ok(addResult.minted?.raw, "Add liquidity response should include minted amount");
-assert.notStrictEqual(addResult.minted.raw, "0", "Minted amount should be greater than zero");
+assert.ok(
+  addResult.pool?.address,
+  "Add liquidity response should include pool information"
+);
+assert.ok(
+  addResult.minted?.raw,
+  "Add liquidity response should include minted amount"
+);
+assert.notStrictEqual(
+  addResult.minted.raw,
+  "0",
+  "Minted amount should be greater than zero"
+);
 
 const removePayload = {
   tokenA: "RIDE",
@@ -64,45 +55,34 @@ const removePayload = {
   seed: "test-seed",
 };
 
-const removeResult = parseBody(await removeLiquidityHandler(buildEvent(removePayload)));
-assert.ok(removeResult.pool?.address, "Remove liquidity response should include pool information");
-assert.ok(removeResult.withdrawals?.tokenA?.amountRaw, "Remove liquidity response should include token A withdrawal");
+const removeResult = parseBody(
+  await removeLiquidityHandler(buildEvent(removePayload))
+);
+assert.ok(
+  removeResult.pool?.address,
+  "Remove liquidity response should include pool information"
+);
+assert.ok(
+  removeResult.withdrawals?.tokenA?.amountRaw,
+  "Remove liquidity response should include token A withdrawal"
+);
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-
-codex/update-addliquidity-and-removeliquidity-functions-ipb5ij
-
-codex/update-addliquidity-and-removeliquidity-functions-gkkb6z
-master
-master
-master
-master
 const walletPayload = {
   seed: "test-seed",
   accountIndex: 0,
 };
 
 const walletResult = parseBody(await walletHandler(buildEvent(walletPayload)));
-assert.equal(walletResult.seed, walletPayload.seed, "Wallet response should echo the input seed");
+assert.equal(
+  walletResult.seed,
+  walletPayload.seed,
+  "Wallet response should echo the input seed"
+);
 assert.ok(walletResult.address, "Wallet response should include a derived address");
-assert.equal(walletResult.baseToken?.symbol, "KTA", "Wallet response should include base token metadata");
+assert.equal(
+  walletResult.baseToken?.symbol,
+  "KTA",
+  "Wallet response should include base token metadata"
+);
 
-codex/update-addliquidity-and-removeliquidity-functions-blqnrv
-
-codex/update-addliquidity-and-removeliquidity-functions-u8dz3r
-
-codex/update-addliquidity-and-removeliquidity-functions-no9t62
-
-codex/update-addliquidity-and-removeliquidity-functions-ipb5ij
-
-
-master
-master
-master
-master
-master
 console.log("Offline smoke test passed");


### PR DESCRIPTION
## Summary
- clean up the wallet Netlify function that was filled with merge artifact markers
- ensure the handler still loads offline fixtures before falling back to live network metadata
- restore the offline smoke test so it imports the wallet handler exactly once

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc71975c288328a64002cad462903f